### PR TITLE
Update qubinode_ansible.sh

### DIFF
--- a/lib/qubinode_ansible.sh
+++ b/lib/qubinode_ansible.sh
@@ -24,9 +24,9 @@ function ensure_supported_ansible_version () {
         if [ "A${AVAILABLE_VERSION}" != "A" ]
         then
             if [[ $RHEL_VERSION == "RHEL8" ]]; then
-                sudo dnf install "ansible-${AVAILABLE_VERSION}" -y
+                sudo dnf install "ansible-${AVAILABLE_VERSION}" git -y
             elif [[ $RHEL_VERSION == "RHEL7" ]]; then
-                sudo yum install "ansible-${AVAILABLE_VERSION}" -y
+                sudo yum install "ansible-${AVAILABLE_VERSION}" git -y
             fi
         else
             printf "%s\n" " Could not find any available version of ansible greater than the"


### PR DESCRIPTION
added git to the installed packages. when you run ./qubinode-installer -m ansible, you get an error since it cannot download the required roles due to not having git installed. Same error occurs when you run the ./qubinode-installer default. I was not sure where to put this, so i went with the first possible option.